### PR TITLE
Feature(#172): Add changelog

### DIFF
--- a/_bookdown.yml
+++ b/_bookdown.yml
@@ -140,6 +140,11 @@ rmd_files:
     -   "chapters/observer_data_indicator.Rmd"
     -   "chapters/Seabird_MAB.Rmd"
     -   "chapters/wind_habitat_occupancy.Rmd"
+#
+#
+# #################### RESOURCES ##################
+    -   "chapters/sectionHeaders/resources.rmd"
+    -   "chapters/changelog.Rmd"
     -   "chapters/references.Rmd"
 before_chapter_script: _common.R
 delete_merged_file: true

--- a/chapters/changelog.Rmd
+++ b/chapters/changelog.Rmd
@@ -1,0 +1,51 @@
+# Changelog {.unnumbered}
+
+## tech-doc 7.0.0 {.unnumbered}
+
+Date: 07/13/2026
+
+Release includes processes and .Rmd files used to build the version of the Technical Documentation referenced in the 2026 State of the Ecosystem reports.
+
+## tech-doc 6.0.0 {.unnumbered}
+
+Date: 09/18/2025
+
+Release includes processes and .Rmd files used to build the version of the Technical Documentation referenced in the 2025 State of the Ecosystem reports. Uses [ecodata 6.0.1](https://github.com/NOAA-EDAB/ecodata/releases/tag/6.0.1).
+
+## tech-doc 5.0.0 {.unnumbered}
+
+Date: 08/29/2024
+
+Release includes processes and .Rmd files used to build the version of the Technical Documentation referenced in the 2024 State of the Ecosystem reports submitted to the MAFMC SSC. Uses [ecodata 5.0.1](https://github.com/NOAA-EDAB/ecodata/releases/tag/5.0.1).
+
+## tech-doc 4.0.0 {.unnumbered}
+
+Date: 08/01/2023
+
+Release includes the methodology for indicators used to build the MAFMC and NEFMC 2023 State of the Ecosystem Reports.
+
+## tech-doc 3.0.0 {.unnumbered}
+
+Date: 09/14/2022
+
+Release includes the methodology for indicators used to build the MAFMC and NEFMC 2022 State of the Ecosystem Reports.
+
+## tech-doc 2.1.0 {.unnumbered}
+
+Date: 04/09/2021
+
+Release includes the methodology for indicators used to build the MAFMC and NEFMC 2021 State of the Ecosystem Reports.
+
+## tech-doc 2.0.0 {.unnumbered}
+
+Date: 06/08/2020
+
+Within this repository is the [technical documentation](https://doi.org/10.25923/64pf-sc70) for the 2020 State of the Ecosystem (SOE) reports, including relevant indicator metadata, literature cited, and scripts for processing and analyses. Indicators described in this documentation were those included in the SOE reports delivered to the Mid-Atlantic Fishery Management Council (MAFMC) and New England Fishery Management Council (NEFMC) in the spring of 2020.
+
+## tech-doc 1.0.0 {.unnumbered}
+
+Date: 12/19/2019
+
+Within this repository is the technical documentation for the 2018/2019 State of the Ecosystem (SOE) reports, including relevant indicator metadata, literature cited, and scripts for processing and analyses. Indicators described in this documentation were those included in the SOE reports delivered to the Mid-Atlantic Fishery Management Council (MAFMC) and New England Fishery Management Council (NEFMC) in the spring of 2018/2019. View the New England reports [2018](https://github.com/NOAA-EDAB/tech-doc/files/3984008/SOE_2018_NEMFC.pdf)and [2019](https://github.com/NOAA-EDAB/tech-doc/files/3984012/SOE_2019_NEMFC.pdf), and the Mid-Atlantic reports [2018](https://github.com/NOAA-EDAB/tech-doc/files/3984006/SOE_2018_MAMFC.pdf) and [2019](https://github.com/NOAA-EDAB/tech-doc/files/3984010/SOE_2019_MAMFC.pdf).
+
+There are multiple ways to build this version of the repository locally in RStudio, including through the remotes package (e.g. remotes::install_github('noaa-edab/tech-memo@v1.0.0')). The document may also be built from the zipped files associated with this release.

--- a/chapters/sectionHeaders/resources.rmd
+++ b/chapters/sectionHeaders/resources.rmd
@@ -1,0 +1,1 @@
+# (PART\*) Resources {.unnumbered}


### PR DESCRIPTION
### Justification

`tech-doc` should have a changelog because it is a versioned product. In a package, this would be done via a `NEWS.md` and a pkgdown site. To make compatible with bookdown, I've created a new "changelog.Rmd" page and added it to a new "Resources" section, which now also includes the "References" page. I'm open to other approaches, though this seemed the most organic integration with bookdown. I've added past release notes from Github to get us started. Future iterations will have much more detail because `tech-doc` will be adopting proper versioning, which will come with more frequent and thorough releases.

Fixes #172 

### Types of changes

What types of changes does this pull request introduce? Put an `x` in the boxes that apply.
This will inform the new release number.

- [ ] Fix (non-breaking change which fixes a bug)
- [x] Feature (non-breaking change which adds or changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other change (if none of the other choices apply)

### Further comments

Please note that we _will not_ increment the _Tech Doc_ version despite this containing a feature change. We will implement proper Semantic Versioning after the next release.

### Reviewer instructions

On the `feature/i172-changelog` branch, please use `bookdown::render_book()` and check the new changelog page. In addition to correctness, review should consider whether this is an agreeable approach to adding a changelog to bookdown documents. If this is approved for `tech-doc`, it will be implemented in `catalog` and elsewhere.
