### PR TITLE
Refactor!(#174): Change default branch from `master` to `main`

### DIFF
--- a/.github/workflows/bookdown.yaml
+++ b/.github/workflows/bookdown.yaml
@@ -3,12 +3,12 @@
 on:
   push:
     branches:
-      - master
+      - main
       - dev
       
   pull_request:
     branches:
-      - master
+      - main
 
 
 name: build-book

--- a/.github/workflows/verify_pr.yml
+++ b/.github/workflows/verify_pr.yml
@@ -2,7 +2,7 @@ name: Run PR Checks
 on:
   pull_request:
     branches:
-    - master
+    - main
 
 jobs:
   check_description:

--- a/_output.yml
+++ b/_output.yml
@@ -14,7 +14,7 @@ bookdown::gitbook:
     #   collapse: section
     #   before: |
     #     <li><a href="./">Mastering Shiny</a></li>
-    edit: https://github.com/NOAA-EDAB/tech-doc/edit/master/%s
+    edit: https://github.com/NOAA-EDAB/tech-doc/edit/main/%s
     download: []
     sharing:
       facebook: no
@@ -42,7 +42,7 @@ bookdown::epub_book: default
 #            <li><a href="https://github.com/NOAA-EDAB/tech-doc" target="blank">Published with bookdown</a></li>
 #    toolbar:
 #       position: static
-#     edit: https://github.com/NOAA-EDAB/tech-doc/edit/master/%s
+#     edit: https://github.com/NOAA-EDAB/tech-doc/edit/main/%s
 #     download: ["pdf"]
 # bookdown::pdf_book:
 #   keep_tex: yes
@@ -62,6 +62,6 @@ bookdown::epub_book: default
 #        <li><a href="https://github.com/NOAA-EDAB/tech-doc"></a></li>
 #        <li><a href="./"Published with bookdown</a></li>
 #    edit:
-#      link: https://github.com/NOAA-EDAB/tech-doc/edit/master/%s
+#      link: https://github.com/NOAA-EDAB/tech-doc/edit/main/%s
 #bookdown::pdf_book:
 #  keep_tex: yes

--- a/chapters/how_we_published.Rmd
+++ b/chapters/how_we_published.Rmd
@@ -23,7 +23,7 @@ Copied in the order I did things to implement gh-pages:
 
 >An alternative approach is to create a `gh-pages` branch in your repository, build the book, put the HTML output (including all external resources like images, CSS, and JavaScript files) in this branch, and push the branch to the remote repository. If your book repository does not have the `gh-pages` branch, you may use the following commands to create one:
 
-**Sarah's notes**: Do this on your _local_ machine, using the terminal under the git-tracked directory, pushing to the github repo last. Don't be tempted to make the gh-pages branch on github first, it causes pain. Using [checkout --orphan](https://git-scm.com/docs/git-checkout) means you are making a new branch that has no history (you don't need to carry the version control history here; it stays on the master branch). Next you are removing all the files from this new branch using [rm -rf .](https://git-scm.com/docs/git-rm) because it will only have the compiled book files on it. All rmd files, etc will remain on the master branch. At the end of this step in the terminal you push to create the gh-pages branch on github. You should see it there, containing only .nojekyll
+**Sarah's notes**: Do this on your _local_ machine, using the terminal under the git-tracked directory, pushing to the github repo last. Don't be tempted to make the gh-pages branch on github first, it causes pain. Using [checkout --orphan](https://git-scm.com/docs/git-checkout) means you are making a new branch that has no history (you don't need to carry the version control history here; it stays on the main branch). Next you are removing all the files from this new branch using [rm -rf .](https://git-scm.com/docs/git-rm) because it will only have the compiled book files on it. All rmd files, etc will remain on the main branch. At the end of this step in the terminal you push to create the gh-pages branch on github. You should see it there, containing only .nojekyll
 
 >
 >From bookdown github chapter:
@@ -43,8 +43,8 @@ git add .nojekyll
 git commit -m"Initial commit"
 git push origin gh-pages
 
-# when done, go back to master branch
-git checkout master
+# when done, go back to main branch
+git checkout main
 ```
 >    
 >
@@ -135,7 +135,7 @@ Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::gitbook')"
 set -e
 
 [ -z "${GITHUB_PAT}" ] && exit 0
-[ "${TRAVIS_BRANCH}" != "master" ] && exit 0
+[ "${TRAVIS_BRANCH}" != "main" ] && exit 0
 
 git config --global user.email "Sarah.Gaichas@noaa.gov"
 git config --global user.name "Sarah Gaichas"


### PR DESCRIPTION
### Justification

In recent years, the industry standard default branch name has changed from `master` to `main`. Adopting this standard will align this repository with others in EDAB, allow for more seamless integration of external tools and clarify collaboration with external partners. We can make this switch with minimal disruption and, therefore, benefit from the standardization without any tradeoffs. Acceptance of these changes will resolve #174.

### Types of changes

What types of changes does this pull request introduce?

- [ ] Fix (non-breaking change which fixes a bug)
- [ ] Feature (non-breaking change which adds or changes functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other change (if none of the other choices apply)

### Further comments

Even though none of the changes in this PR are breaking, this should still be considered a breaking change because end users will need to update their local clones in response to renaming the default branch.

There may be other downstream consequences of making this switch but they will be minor and should be very easy to handle. Any changes required elsewhere should be noted in separate issues and resolved independently of this initial PR.

### Reviewer instructions

This is one of many upcoming changes that will be handled exclusively by repository maintainers. These changes only affect product/repository infrastructure and do not involve any changes to content which would require an additional reviewer. @andybeet you will be the only reviewer, and may bypass restrictions to approve and merge. Please briefly review the changes for proper syntax and spelling. No other testing is required.